### PR TITLE
add main-next-release to test workflows

### DIFF
--- a/.github/workflows/test-dev.yml
+++ b/.github/workflows/test-dev.yml
@@ -5,9 +5,11 @@ on:
   pull_request:
     branches:
       - main
+      - main-next-release
   push:
     branches:
       - main
+      - main-next-release
 
 jobs:
   test:

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ For those that understand, this package is a ZMQ/HTTP-RPC.
 [![Conda Downloads](https://img.shields.io/conda/d/conda-forge/hololinked)](https://anaconda.org/conda-forge/hololinked)
 <br>
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.15155942.svg)](https://doi.org/10.5281/zenodo.12802841)
+[![Discord](https://img.shields.io/discord/1265289049783140464?label=Discord%20Members&logo=discord)](https://discord.com/invite/kEz87zqQXh) 
 
 ### To Install
 
@@ -343,6 +344,6 @@ Again, please check examples or the code for explanations. Documentation is bein
 ### Contributing
 
 See [organization info](https://github.com/hololinked-dev) for details regarding contributing to this package. There is:
-- discord group - [![Discord](https://img.shields.io/discord/1265289049783140464?label=Discord%20Members&logo=discord)](https://discord.com/invite/kEz87zqQXh) 
+- [discord group](https://discord.com/invite/kEz87zqQXh)
 - [weekly meetings](https://github.com/hololinked-dev/#monthly-meetings) and 
 - [project planning](https://github.com/orgs/hololinked-dev/projects/4)  to discuss activities around this repository. 


### PR DESCRIPTION
creating `main-next-release` branch for next release (v0.3 and v0.4) which will support more clearly the separation of protocol bindings from `Thing` object. 

Need to bring all changes in develop branch step by step into the branch, therefore adding CI conditions.   